### PR TITLE
esp_capture: fix bitrate setter for video/audio; plumb to encoder (AUD-6880)

### DIFF
--- a/packages/esp_capture/src/esp_capture.c
+++ b/packages/esp_capture/src/esp_capture.c
@@ -1110,15 +1110,15 @@ esp_capture_err_t esp_capture_sink_set_bitrate(esp_capture_sink_handle_t h, esp_
     int ret = ESP_CAPTURE_ERR_NOT_SUPPORTED;
     if (stream_type == ESP_CAPTURE_STREAM_TYPE_VIDEO) {
         type = ESP_CAPTURE_PATH_SET_TYPE_VIDEO_BITRATE;
-        esp_capture_path_mngr_if_t *audio_path = &capture->cfg.audio_path->base;
-        if (audio_path) {
-            audio_path->set(audio_path, path->path_type, type, &bitrate, sizeof(uint32_t));
+        esp_capture_path_mngr_if_t *video_path = &capture->cfg.video_path->base;
+        if (video_path && video_path->set) {
+            ret = video_path->set(video_path, path->path_type, type, &bitrate, sizeof(uint32_t));
         }
     } else if (stream_type == ESP_CAPTURE_STREAM_TYPE_AUDIO) {
         type = ESP_CAPTURE_PATH_SET_TYPE_AUDIO_BITRATE;
-        esp_capture_path_mngr_if_t *video_path = &capture->cfg.video_path->base;
-        if (video_path) {
-            video_path->set(video_path, path->path_type, type, &bitrate, sizeof(uint32_t));
+        esp_capture_path_mngr_if_t *audio_path = &capture->cfg.audio_path->base;
+        if (audio_path && audio_path->set) {
+            ret = audio_path->set(audio_path, path->path_type, type, &bitrate, sizeof(uint32_t));
         }
     }
     capture_mutex_unlock(capture->api_lock);


### PR DESCRIPTION
This PR fixes #29: runtime bitrate control for `esp_capture` by correctly forwarding sink bitrate changes to the capture path manager and ultimately the video encoder element. 

1. What was wrong

The current `esp_capture_sink_set_bitrate`(...) returned `ESP_CAPTURE_ERR_NOT_SUPPORTED` and mixed audio/video handling, so bitrate updates never reached the GMF video encoder.

2. What this changes

Dispatches by stream_type and calls path_mngr->set(..., ESP_CAPTURE_PATH_SET_TYPE_{VIDEO|AUDIO}_BITRATE, ...), which stores the bitrate and applies it immediately if the encoder element is already created (or on prepare/start otherwise).

3. Motivation / context

I’m using espressif/esp-webrtc-solution for a WebRTC sender pipeline. That repo uses esp_capture for media but currently does not expose a public API to change bitrate at runtime, so I added a small wrapper on that side which calls into esp_capture_sink_set_bitrate(...). I plan to open a companion PR in esp-webrtc-solution to expose this API officially. The esp-webrtc-solution README explicitly lists esp_capture as the media capture component. 
[GitHub](https://github.com/espressif/esp-webrtc-solution)

4. Testing

Environment

ESP-IDF: latest

Board: ESP32-P4

Verified return code is OK and visual quality/throughput adapts; logs show the encoder path receiving updated bitrate.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [X] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.
