### PR TITLE
fix(board_manager): default disabled PA pin to -1 instead of GPIO0 (AUD-7247)

### DIFF
--- a/packages/esp_board_manager/devices/dev_audio_codec/dev_audio_codec.py
+++ b/packages/esp_board_manager/devices/dev_audio_codec/dev_audio_codec.py
@@ -65,7 +65,7 @@ def _parse_codec_peripherals(device_name: str, peripherals: list, peripherals_di
     # so keep zero/default struct initializers instead of None/NULL.
     pa_cfg = {
         'name': None,
-        'port': 0,
+        'port': -1,
         'active_level': 0,
         'gain': 0.0,
     }


### PR DESCRIPTION
## Description

Fixes the default `pa_cfg` initialization in `dev_audio_codec.py` when no PA peripheral is configured.

**Problem**

When an `audio_codec` device does not define `gpio_pa_control`, `_parse_codec_peripherals()` initializes:

- `pa_cfg.name = NULL`
- `pa_cfg.port = 0`

On ESP32-class targets, **GPIO0 is a valid GPIO number**, so `0` is ambiguous with “PA disabled” and can conflict with boards that use **GPIO0 as I2S BCLK** (see discussion in issue #42).

**Change (this PR)**

- Change the default `pa_cfg.port` from `0` to `-1` when PA is not configured.

**Out of scope (tracked separately / follow-up)**

- Runtime hardening in `dev_audio_codec.c` (only apply `pa_pin` when PA is explicitly configured) is suggested in #42 but **not included** in this PR to keep the change minimal.

## Related

Fixes https://github.com/espressif/esp-gmf/issues/42

## Testing

- Ran `idf.py gen-bmgr-config` for a board where `audio_codec` has **no** `gpio_pa_control`.
- Verified generated `gen_board_device_config.c` shows `pa_cfg.port = -1` when PA is absent.

---

## Checklist

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.