### PR TITLE
fix(esp_board_manager): drive DVP XCLK via LEDC before esp_video_init (AUD-7254)

### DIFF
--- a/packages/esp_board_manager/devices/dev_camera/dev_camera_sub_dvp.c
+++ b/packages/esp_board_manager/devices/dev_camera/dev_camera_sub_dvp.c
@@ -13,8 +13,12 @@
 #include "esp_board_device.h"
 #include "esp_board_entry.h"
 #include "esp_video_device.h"
+#include "driver/ledc.h"
 
 static const char *TAG = "DEV_CAMERA_SUB_DVP";
+
+#define DVP_XCLK_LEDC_TIMER     LEDC_TIMER_1
+#define DVP_XCLK_LEDC_CHANNEL   LEDC_CHANNEL_1
 
 int dev_camera_sub_dvp_init(void *cfg, int cfg_size, void **device_handle)
 {
@@ -31,14 +35,49 @@ int dev_camera_sub_dvp_init(void *cfg, int cfg_size, void **device_handle)
         return -1;
     }
 
+    // ESP32-S3 DVP controller does not output XCLK until CAM transfer starts.
+    // esp_video's init_dvp_clk_func configures the DVP clock divider and also
+    // re-routes the GPIO to the DVP peripheral signal, which overrides any
+    // LEDC output on that pin. Since CAM transfer is not started during init,
+    // the pin ends up with no clock, and OV2640 cannot respond to SCCB.
+    // Workaround: tell esp_video that XCLK is not used (xclk_io = -1), and
+    // drive XCLK ourselves via LEDC before esp_video_init.
+    if (config->sub_cfg.dvp.dvp_io.xclk_io >= 0 && config->sub_cfg.dvp.xclk_freq > 0) {
+        ledc_timer_config_t ledc_timer = {
+            .speed_mode = LEDC_LOW_SPEED_MODE,
+            .duty_resolution = LEDC_TIMER_1_BIT,
+            .timer_num = DVP_XCLK_LEDC_TIMER,
+            .freq_hz = config->sub_cfg.dvp.xclk_freq,
+            .clk_cfg = LEDC_AUTO_CLK,
+        };
+        ledc_channel_config_t ledc_channel = {
+            .gpio_num = config->sub_cfg.dvp.dvp_io.xclk_io,
+            .speed_mode = LEDC_LOW_SPEED_MODE,
+            .channel = DVP_XCLK_LEDC_CHANNEL,
+            .timer_sel = DVP_XCLK_LEDC_TIMER,
+            .duty = 1,
+            .hpoint = 0,
+        };
+        ESP_LOGI(TAG, "Starting LEDC XCLK on GPIO %d, freq %lu Hz",
+                 config->sub_cfg.dvp.dvp_io.xclk_io, config->sub_cfg.dvp.xclk_freq);
+        ledc_timer_config(&ledc_timer);
+        ledc_channel_config(&ledc_channel);
+    }
+
+    // Copy DVP pin config but mask out xclk_io so esp_video_init does not
+    // re-configure the GPIO to the DVP peripheral signal (which would stop
+    // the LEDC clock).
+    esp_cam_ctlr_dvp_pin_config_t dvp_pin = config->sub_cfg.dvp.dvp_io;
+    dvp_pin.xclk_io = GPIO_NUM_NC;
+
     esp_video_init_dvp_config_t s_dvp_config = {
         .sccb_config.init_sccb = false,
         .sccb_config.i2c_handle = i2c_handle,
         .sccb_config.freq = config->sub_cfg.dvp.i2c_freq,
         .reset_pin = config->sub_cfg.dvp.reset_io,
         .pwdn_pin = config->sub_cfg.dvp.pwdn_io,
-        .dvp_pin = config->sub_cfg.dvp.dvp_io,
-        .xclk_freq = config->sub_cfg.dvp.xclk_freq,
+        .dvp_pin = dvp_pin,
+        .xclk_freq = 0,  // xclk is driven by LEDC, not DVP controller
     };
 
     const esp_video_init_config_t cam_config = {
@@ -76,6 +115,9 @@ int dev_camera_sub_dvp_deinit(void *device_handle)
     if (ret != ESP_OK) {
         ESP_LOGE(TAG, "Failed to deinitialize DVP camera: %s", esp_err_to_name(ret));
     }
+
+    // Stop LEDC XCLK
+    ledc_stop(LEDC_LOW_SPEED_MODE, DVP_XCLK_LEDC_CHANNEL, 0);
 
     dev_camera_config_t *cfg = NULL;
     esp_board_device_get_config_by_handle(handle, (void **)&cfg);


### PR DESCRIPTION
## Problem
On ESP32-S3, the DVP controller does not output XCLK until CAM transfer begins. `esp_video` routes the GPIO to the DVP peripheral at init time, but no clock is emitted. OV-family sensors need a live XCLK to respond to SCCB, so sensor probing fails at boot:

```
E ov3660: get sensor ID failed
E esp_video_init: Failed to detect camera sensor with address=3c
```

Any board using an OV-family DVP camera on ESP32-S3 through `esp_board_manager 0.5.10` hits this out of the box.

## Fix
In `dev_camera_sub_dvp_init`, before calling `esp_video_init`:
- If `xclk_io >= 0 && xclk_freq > 0`, start LEDC on that GPIO at the requested frequency (1-bit resolution, 50% duty).
- Mask `xclk_io` to `GPIO_NUM_NC` and pass `xclk_freq = 0` to `esp_video` so it does not re-route the pin.

On deinit, `ledc_stop` to release the channel.

The guard `xclk_io >= 0 && xclk_freq > 0` makes this a no-op for boards that don't use DVP XCLK via GPIO (e.g. MIPI-CSI).

## Note on long-term direction
The SPI path already uses `esp_cam_sensor_xclk_*` for this purpose via `init_spi_clk_func`. Adding an `xclk_source` field to the DVP YAML schema so DVP can use the same API is the symmetrical refactor. Happy to do that in a follow-up PR if preferred — this PR keeps scope minimal to unblock users.

## Test
ESP32-S3 SparkBot + OV3660 DVP:
- Without patch: `get sensor ID failed` at boot.
- With patch: `ov3660: Detected Camera sensor PID=0x3660`, `/dev/video2` opens from Lua, `camera.capture()` writes a ~30 KB JPEG.

Tested against ESP-IDF v5.5.4.